### PR TITLE
fix call APi

### DIFF
--- a/src/epfl-news/inspector.js
+++ b/src/epfl-news/inspector.js
@@ -59,7 +59,7 @@ export default class InspectorControlsNews extends Component {
         
         let content = "";
         
-        if (this.state.channels !== null) {
+        if (this.state.channels !== null && this.state.categories !== null && this.state.themes !== null) {
             
             let optionsChannelsList = [];
 


### PR DESCRIPTION
On fait des appels à l'api rest d'actu pour les "remplir" les listes déroulantes categories et les themes mais je ne checkais pas que l'appel avait successfull
