### PR TITLE
Fix title

### DIFF
--- a/frontend/epfl-introduction/view.php
+++ b/frontend/epfl-introduction/view.php
@@ -16,7 +16,7 @@ function epfl_introduction_block( $attributes ) {
     $markup .= '<div class="row">';
     $markup .= '<div class="col-md-8 offset-md-2">';
     $markup .= '<h2>';
-    $markup .= esc_html($content);
+    $markup .= esc_html($title);
     $markup .= '</h2>';
     $markup .= '<p>';
     $markup .= esc_html($content);


### PR DESCRIPTION
Le titre du bloc introduction n'était pas utilisé lors de l'affichage (c'était le contenu à la place)