### PR TITLE
Activate core block heading

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -51,6 +51,7 @@ function my_plugin_allowed_block_types( $allowed_block_types, $post ) {
         'epfl/social-feed',
         'epfl/contact',
         'core/paragraph',
+        'core/heading',
     );
 
     // Add epfl/scienceqa block for WP instance https://www.epfl.ch only


### PR DESCRIPTION
Sur demande de Adrian (Mediacom), activation du core bloc Heading pour permettre à l'utilisateur d'ajouter des titres à l'endroit qu'il le souhaite dans la page.
C'est le 2ème bloc core après le bloc paragraphe.