### PR TITLE
EPFL News: Adapt to new way to save themes

### DIFF
--- a/frontend/epfl-news/controller.php
+++ b/frontend/epfl-news/controller.php
@@ -49,7 +49,7 @@ function epfl_news_get_limit($template, $nb_news)
  * @param $template: id of template
  * @param $lang: lang of news
  * @param $category: id of news category
- * @param $themes: The list of news themes id. For example: 1,2,5
+ * @param $themes: string representing a list  of associative arrays. Ex: '[{"value":4,"label":"Engineering"}]'
  * @return the api URL of news
  */
 function epfl_news_build_api_url($channel, $template, $nb_news, $lang, $category, $themes, $projects)
@@ -66,11 +66,9 @@ function epfl_news_build_api_url($channel, $template, $nb_news, $lang, $category
     }
 
     // filter by themes
-    if ($themes !== '' && $themes != '[]') {
-        $themes = explode(',', $themes);
-        foreach ($themes as $theme) {
-            $url .= '&themes=' . $theme;
-        }
+    $themes = json_decode($themes, true);
+    foreach ($themes as $theme) {
+        $url .= '&themes=' . $theme['value'];
     }
 
     // filter by projects

--- a/src/epfl-news/index.js
+++ b/src/epfl-news/index.js
@@ -12,7 +12,7 @@ registerBlockType(
 	'epfl/news',
 	{
 		title: __( "EPFL News", 'wp-gutenberg-epfl'),
-		description: 'v1.0.0',
+		description: 'v1.0.1',
 		icon: newsIcon,
 		category: 'common',
 		keywords: [


### PR DESCRIPTION
La nouvelle manière de stocker la liste des "thèmes" avait bien été prise en compte lors du développement de la partie backend pour récupérer les informations dans l'API News mais la partie frontend avait été oubliée...