### PR TITLE
Delete all spaces

### DIFF
--- a/frontend/epfl-people/controller.php
+++ b/frontend/epfl-people/controller.php
@@ -46,6 +46,11 @@ function epfl_people_block( $attributes ) {
     var_dump($columns);
     */
 
+    // Delete all whitespace (including tabs and line ends)
+    $units = preg_replace('/\s+/','',$units);
+    $scipers = preg_replace('/\s+/','',$scipers);
+    $doctoral_program = preg_replace('/\s+/','',$doctoral_program);
+    
     if ($columns !== 'list') {
         $columns = (is_numeric($columns) && intval($columns) <= 3 && intval($columns) >= 1) ? $columns : 3;
     }


### PR DESCRIPTION
Les champs suivants : units, scipers et doctoral_program peuvent contenir des espaces, tabulations). Il faut donc les supprimer.