### PR TITLE
Fix default lang render

### DIFF
--- a/frontend/epfl-news/controller.php
+++ b/frontend/epfl-news/controller.php
@@ -106,7 +106,7 @@ function epfl_news_check_required_parameters($channel, $lang) {
 function epfl_news_block( $attributes ) {
 
   $channel       = Utils::get_sanitized_attribute( $attributes, 'channel', 1 );
-  $lang          = Utils::get_sanitized_attribute( $attributes, 'lang', 'fr' );
+  $lang          = Utils::get_sanitized_attribute( $attributes, 'lang', 'en' );
   $template      = Utils::get_sanitized_attribute( $attributes,'template', 'listing' );
   $all_news_link = Utils::get_sanitized_attribute( $attributes, 'displayLinkAllNews', FALSE );
   $nb_news       = Utils::get_sanitized_attribute( $attributes, 'nbNews', 3 );


### PR DESCRIPTION
Corrige un problème dans le bloc epfl-news.
Lorsqu'un paramètre est setté avec sa valeur par défaut, il n'est pas transmis au render. Donc il faut que la config gutenberg et la config du render php aient les mêmes valeurs par défaut.
La langue par défaut dans gutenberg est l'anglais mais dans le render php elle était en français.