### PR TITLE
Fix epfl links group

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: greglebarbar
- * Version: 1.0.3
+ * Version: 1.0.4
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/src/epfl-links-group/index.js
+++ b/src/epfl-links-group/index.js
@@ -8,6 +8,10 @@ const {
     TextControl,
 } = wp.components;
 
+const {
+	InspectorControls,
+} = wp.editor
+
 const { Fragment } = wp.element;
 
 const maxLinksGroup = 10;
@@ -65,7 +69,7 @@ function LinkGroupPanel ( props ) {
 
 registerBlockType( 'epfl/links-group', {
 	title: __( 'EPFL Links group', 'wp-gutenberg-epfl'),
-	description: 'v1.0.1',
+	description: 'v1.0.2',
 	icon: 'editor-kitchensink',
 	category: 'common',
 	attributes: getAttributes(),


### PR DESCRIPTION
Il manquait un import pour le bloc epfl-links-group 