### PR TITLE
More flexibility into phone number formatting

### DIFF
--- a/frontend/epfl-people/templates/card.php
+++ b/frontend/epfl-people/templates/card.php
@@ -57,7 +57,7 @@ namespace EPFL\Plugins\Gutenberg\People;
                 $markup .= '<a class="btn btn-block btn-primary mb-2" href="mailto:' . esc_attr($person->email) . '">' . esc_html($person->email) . '</a>';
             }
             if (isset($phones[0])) {
-                $markup .= '<a class="btn btn-block btn-secondary" href="tel:+412169' . esc_html($phones[0]) . '">+41 21 69 ' . esc_html($phones[0]) . '</a>';
+                $markup .= '<a class="btn btn-block btn-secondary" href="tel:+412169' . esc_html($phones[0]) . '">' . esc_html($phones[0]) . '</a>';
             }
             $markup .= '</div>';
             $markup .= '</div>';

--- a/frontend/epfl-people/templates/list.php
+++ b/frontend/epfl-people/templates/list.php
@@ -36,7 +36,7 @@ namespace EPFL\Plugins\Gutenberg\People;
             
             if (isset($phones[0])) { 
                 $markup .= '<a class="contact-list-item text-muted" href="tel:"'. esc_html($phones[0]) . '" itemprop="telephone">';
-                $markup .= '+41 21 69 <b>' . esc_html($phones[0]) . '</b>';
+                $markup .= '<b>' . esc_html($phones[0]) . '</b>';
             }
 
             $markup .= '</a>';

--- a/frontend/epfl-people/utils.php
+++ b/frontend/epfl-people/utils.php
@@ -7,7 +7,7 @@ namespace EPFL\Plugins\Gutenberg\People;
  */
 function epfl_people_get_photo($person) {
     $photo_url = "";
-    if ("1" == $person->people->photo_show) {
+    if( property_exists($person, 'people') && "1" == $person->people->photo_show) {
         $photo_url = "https://people.epfl.ch/private/common/photos/links/" . $person->sciper.".jpg";
     }
     return $photo_url;

--- a/frontend/epfl-people/utils.php
+++ b/frontend/epfl-people/utils.php
@@ -21,6 +21,27 @@ function epfl_people_get_phones($person) {
     foreach($person->unites as $current_unit) {
         $phones = array_merge($phones, array_filter($current_unit->phones));
     }
+
+    /* Looping through phone numbers to reformat them to have same format as the one on https://www.local.ch,
+    EX: +41 21 693 22 24 */
+    foreach($phones as $key => $phone){
+        /* If short format (ex: 32224) */
+        if(preg_match('/^([0-9])([0-9]{2,2})([0-9]{2,2})$/', $phone, $matches) === 1)
+        {
+            unset($matches[0]); // remove full phone number (equivalent to $phone)
+            $phones[$key] = "+41 21 69".implode(" ", $matches);
+        }
+        /* if long format without international (ex: 0216932224) */
+        elseif(preg_match('/^([0-9])([0-9]{2,2})([0-9]{3,3})([0-9]{2,2})([0-9]{2,2})$/', $phone, $matches) === 1)
+        {
+            unset($matches[0]); // remove full phone number (equivalent to $phone)
+            unset($matches[1]); // remove first digit (0) before local indentifier
+            $phones[$key] = "+41 ".implode(" ", $matches);
+        }
+        
+        /* There's no other condition to reformat because normally there is no other format in people.epfl.ch */
+    }
+    
     return array_unique($phones);
 }
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: greglebarbar
- * Version: 1.0.11
+ * Version: 1.0.12
  */
 
 namespace EPFL\Plugins\Gutenberg;


### PR DESCRIPTION
Portage de la PR https://github.com/epfl-idevelop/wp-theme-2018/pull/230 qui avait été oubliée... donc potentiellement certains no de téléphone pouvaient encore s'afficher faux depuis le passage à Gutenberg.

La modification permet donc de corriger un petit problème existant mais assure aussi un passage transparent à la nouvelle manière de stocker les no de téléphone dans l'API de People. Comme ça, le jour où on bascule, aucune modification à faire.

Correction d'un petit bug:
> Undefined property: stdClass::$people in /wp/5.2.3/wp-content/plugins/wp-gutenberg-epfl/frontend/epfl-people/utils.php on line 10