### PR TITLE
Fix publication list not being rendered with an empty p tag

### DIFF
--- a/frontend/epfl-infoscience-search/renderers/publications.php
+++ b/frontend/epfl-infoscience-search/renderers/publications.php
@@ -98,7 +98,7 @@ abstract Class InfosciencePublication2018Render {
 
     protected static function render_links($publication) {
         $links_html = '<div class="col-md-2 text-right mt-4 mt-md-0">';
-        $links_html .= '  <p>';
+        $links_html .= '  <p class="infoscience_detailed_record_link">';
         $links_html .= '    <a href="//infoscience.epfl.ch/record/' . $publication['record_id'][0] . '" class="btn btn-secondary btn-sm" target="_blank">' . esc_html__('Detailed record', 'wp-gutenberg-epfl') . '</a>';
         $links_html .= '  </p>';
 


### PR DESCRIPTION
Because WP is cleaning the whole html of the block without this. Resolve INC0311995
