### PR TITLE
Enforce source URL check for GoogleForms iframes

### DIFF
--- a/frontend/epfl-google-forms/controller.php
+++ b/frontend/epfl-google-forms/controller.php
@@ -25,6 +25,9 @@ function epfl_google_forms_block( $attributes ) {
     /*
     data contains thing like (encoded):
     <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSeLZkqncWIvRbQvnn3K8yKUEn0Of8s-JTFZ3l94TWAIHnovJA/viewform?embedded=true" width="640" height="663" frameborder="0" marginheight="0" marginwidth="0">Chargement en cours...</iframe>
+
+    NOTE:
+    This block also allow to use others subdomains of Google (.google.com) like maps, calendar, etc...
     */
 
     $data = isset( $attributes['data'] ) ? urldecode($attributes['data']) : '';
@@ -45,9 +48,11 @@ function epfl_google_forms_block( $attributes ) {
     {
         return Utils::render_user_msg(__("Error extracting parameters", "epfl"));
     }
-
-    /* Check that iframe has a Google Forms URL as source */
-    if(strpos($src, 'https://docs.google.com/forms') > 0)
+    /* Extract host name to check it */
+    $url_host = parse_url($src, PHP_URL_HOST);
+    
+    /* Check that iframe has a Google host as source */
+    if(preg_match('/\.google\.com$/', $url_host) !== 1)
     {
         return Utils::render_user_msg(__("Incorrect URL found", "epfl"));
     }

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: greglebarbar
- * Version: 1.0.15
+ * Version: 1.0.16
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/src/epfl-google-forms/index.js
+++ b/src/epfl-google-forms/index.js
@@ -20,7 +20,7 @@ const { Fragment } = wp.element;
 
 registerBlockType( 'epfl/google-forms', {
 	title: __( 'Google Forms', 'wp-gutenberg-epfl'),
-	description: 'v1.0.4',
+	description: 'v1.0.5',
 	icon: googleFormsIcon,
 	category: 'common',
 	attributes: {


### PR DESCRIPTION
Actuellement, le check de la validité de l'URL source de l'iframe est mal fait (je sais pas comment j'ai réussi à coder une daube pareille !). Du coup, toutes les URLs "iframe" pouvaient être mises... Bien la sécurité .. 😭 
Correction pour n'autoriser que les URL dont le host se termine par `.google.com`. Ceci permet d'autoriser les autres fonctionnalités de Google tel que Calendar ou Maps vu qu'il semble qu'elles soient utilisées. 