### PR TITLE
prog doct order alpha

### DIFF
--- a/frontend/epfl-people/controller.php
+++ b/frontend/epfl-people/controller.php
@@ -87,6 +87,8 @@ function epfl_people_block( $attributes ) {
     if (HIERARCHICAL_ORDER === $order && "" !== $units) {
       // People API: &struct=1 parameter corresponds to the hierarchical order
       $parameter['struct'] = '1';
+    } else {
+      $order = ALPHABETICAL_ORDER;
     }
 
     if (function_exists('pll_current_language')) {

--- a/src/epfl-people/inspector.js
+++ b/src/epfl-people/inspector.js
@@ -31,7 +31,7 @@ export default class InspectorControlsPeople extends Component {
         ]
 
         let sortingPanelBody;
-        if (!attributes.scipers && !attributes.groups) {
+        if (!attributes.scipers && !attributes.groups && !attributes.doctoralProgram) {
             sortingPanelBody = <PanelBody title={ __( 'Sorting', 'wp-gutenberg-epfl' ) }>
                     <RadioControl
                         selected={ attributes.order }

--- a/src/epfl-people/inspector.js
+++ b/src/epfl-people/inspector.js
@@ -31,7 +31,7 @@ export default class InspectorControlsPeople extends Component {
         ]
 
         let sortingPanelBody;
-        if (!attributes.scipers && !attributes.groups && !attributes.doctoralProgram) {
+        if (!!attributes.units) {
             sortingPanelBody = <PanelBody title={ __( 'Sorting', 'wp-gutenberg-epfl' ) }>
                     <RadioControl
                         selected={ attributes.order }


### PR DESCRIPTION
Le tri par odre alpha ou hierarchique ne doit s'afficher que dans le cas des units.
