### PR TITLE
Improve loading of pages from the API by getting only needed fields

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -76,6 +76,9 @@ export const getAllPagesOrPosts = async (type='pages', lang=null, fields=['id', 
         }
 
         axios.get(apiRestUrl).then(async (response) => {
+                // Total number of pages on the WP site
+                let nbTotalPages = response.headers["x-wp-total"];
+
                 // Total number of pages (in the pagination sense)
                 let nbPages = response.headers["x-wp-totalpages"];
 
@@ -85,13 +88,26 @@ export const getAllPagesOrPosts = async (type='pages', lang=null, fields=['id', 
                 // get first iteration
                 pages.push(response.data);
 
-                for (let page = 2; page <= nbPages; page += 1) {
-                    let pagesByPagination = await axios.get(`${apiRestUrl}&page=${page}`).catch((err) => { reject(err); });
-                    pages.push(pagesByPagination.data);
+                // is first iteration enough ?
+                if (pages.flat().length == nbTotalPages) {
+                    // all fine ! return what we got
+                    resolve(pages.flat());
                 }
 
-                // all fine ! return what we got
-                resolve(pages.flat());
+                for (let page = 2; page <= nbPages; page += 1) {
+
+                    axios.get(`${apiRestUrl}&page=${page}`).then(
+
+                        pagesByPagination => {
+
+                            pages.push(pagesByPagination.data);
+
+                            if (pages.flat().length == nbTotalPages) {
+                                resolve(pages.flat());
+                            }
+                        }
+                    ).catch( err => reject(err));
+                }
             }
         ).catch( err => reject(err));
     });

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -56,7 +56,7 @@ const getHomeURL = () => {
  *                                  Warning, getting content make a render of the post
  * @return a Promise of a list of pages or posts
  */
-export const getAllPagesOrPosts = (type='pages', lang=null, fields=['id', 'title']) => {
+export const getAllPagesOrPosts = async (type='pages', lang=null, fields=['id', 'title']) => {
     return new Promise((resolve, reject) => {
 
         let homeUrl = getHomeURL();
@@ -75,12 +75,7 @@ export const getAllPagesOrPosts = (type='pages', lang=null, fields=['id', 'title
             fields.forEach((field) => {apiRestUrl += `&_fields[]=${field}`;});
         }
 
-        axios.get(apiRestUrl).then(
-            response => {
-
-                // Total number of pages on the WP site
-                let nbTotalPages = response.headers["x-wp-total"];
-
+        axios.get(apiRestUrl).then(async (response) => {
                 // Total number of pages (in the pagination sense)
                 let nbPages = response.headers["x-wp-totalpages"];
 
@@ -91,13 +86,8 @@ export const getAllPagesOrPosts = (type='pages', lang=null, fields=['id', 'title
                 pages.push(response.data);
 
                 for (let page = 2; page <= nbPages; page += 1) {
-
-                    axios.get(`${apiRestUrl}&page=${page}`).then(
-
-                        pagesByPagination => {
-                            pages.push(pagesByPagination.data);
-                        }
-                    );
+                    let pagesByPagination = await axios.get(`${apiRestUrl}&page=${page}`).catch((err) => { reject(err); });
+                    pages.push(pagesByPagination.data);
                 }
 
                 // all fine ! return what we got

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -38,6 +38,7 @@ import './epfl-card'
 import './epfl-definition-list'
 import './epfl-links-group'
 
+
 const getHomeURL = () => {
     let href = window.location.href;
     let index = href.indexOf('/wp-admin');
@@ -45,18 +46,33 @@ const getHomeURL = () => {
     return homeUrl;
 }
 
-export const getAllPagesOrPosts = (type, lang) => {
 
+/**
+ * Fetch all pages or post from the site
+ * @param {string} type: 'pages' or 'posts'
+ * @param {string} lang: optionnal, set it to limit the list to a specific language
+ * @param {array of string} fields: optionnal, list of fields we want the data for the post.
+ *                                  By default we mainly need the id and the title, ...
+ *                                  Warning, getting content make a render of the post
+ * @return a Promise of a list of pages or posts
+ */
+export const getAllPagesOrPosts = (type='pages', lang=null, fields=['id', 'title']) => {
     return new Promise((resolve, reject) => {
 
         let homeUrl = getHomeURL();
+
         if (type !== 'pages' && type !== 'posts') {
-            type = 'pages';
+            throw new Error("Please set the type parameter to 'pages' or 'posts'");
         }
+
         let apiRestUrl = `${homeUrl}/?rest_route=/wp/v2/${type}&per_page=100`;
 
         if (lang) {
             apiRestUrl += '&lang=' + lang;
+        }
+
+        if (fields) {
+            fields.forEach((field) => {apiRestUrl += `&_fields[]=${field}`;});
         }
 
         axios.get(apiRestUrl).then(
@@ -71,21 +87,22 @@ export const getAllPagesOrPosts = (type, lang) => {
                 // We build a array containing all pages of WP site
                 const pages = [];
 
-                for (let page = 1; page <= nbPages; page += 1) {
+                // get first iteration
+                pages.push(response.data);
+
+                for (let page = 2; page <= nbPages; page += 1) {
 
                     axios.get(`${apiRestUrl}&page=${page}`).then(
 
                         pagesByPagination => {
-
                             pages.push(pagesByPagination.data);
-
-                            if (pages.flat().length == nbTotalPages) {
-                                resolve(pages.flat());
-                            }
                         }
                     );
                 }
+
+                // all fine ! return what we got
+                resolve(pages.flat());
             }
-        ).catch( err => reject(err))
+        ).catch( err => reject(err));
     });
 };

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -75,7 +75,8 @@ export const getAllPagesOrPosts = async (type='pages', lang=null, fields=['id', 
             fields.forEach((field) => {apiRestUrl += `&_fields[]=${field}`;});
         }
 
-        axios.get(apiRestUrl).then(async (response) => {
+        axios.get(apiRestUrl).then(
+            response => {
                 // Total number of pages on the WP site
                 let nbTotalPages = response.headers["x-wp-total"];
 


### PR DESCRIPTION
- Suppression d'un appel par la récupération des données du premier appel
- Limitation des données retournées aux champs spécfique, ce qui évite de couteusement générer le champ "content"