### PR TITLE
EPFL-Contact - Fix display bug when no information

### DIFF
--- a/frontend/epfl-contact/controller.php
+++ b/frontend/epfl-contact/controller.php
@@ -33,7 +33,7 @@ function epfl_contact_block($attributes, $inner_content) {
           endif; ?>
 
           <?php for ($i=1; $i < 5; $i++): ?>
-            <?php if (isset($attributes['timetable'.$i])): ?>
+            <?php if (isset($attributes['timetable'.$i]) && strip_tags($attributes['timetable'.$i])!=""): ?>
           <div class="card card-body card-sm mb-2 flex-row flex-wrap justify-content-between justify-content-sm-start">
             <div class="mr-3 w-sm-50"><?php echo $attributes['timetable'.$i] ?></div>
           </div>
@@ -42,7 +42,7 @@ function epfl_contact_block($attributes, $inner_content) {
           endfor;
           ?>
           <?php for ($i=1; $i < 4; $i++): ?>
-          <?php if (isset($attributes['information'.$i])): ?>
+          <?php if (isset($attributes['information'.$i]) && strip_tags($attributes['information'.$i])!=""): ?>
           <p><?php echo urldecode($attributes['information'.$i]) ?: '' ?></p>
           <hr>
           <?php

--- a/frontend/epfl-contact/controller.php
+++ b/frontend/epfl-contact/controller.php
@@ -33,7 +33,7 @@ function epfl_contact_block($attributes, $inner_content) {
           endif; ?>
 
           <?php for ($i=1; $i < 5; $i++): ?>
-            <?php if (isset($attributes['timetable'.$i]) && strip_tags($attributes['timetable'.$i])!=""): ?>
+            <?php if (Utils::richtext_content_exists($attributes, 'timetable'.$i)): ?>
           <div class="card card-body card-sm mb-2 flex-row flex-wrap justify-content-between justify-content-sm-start">
             <div class="mr-3 w-sm-50"><?php echo $attributes['timetable'.$i] ?></div>
           </div>
@@ -42,7 +42,7 @@ function epfl_contact_block($attributes, $inner_content) {
           endfor;
           ?>
           <?php for ($i=1; $i < 4; $i++): ?>
-          <?php if (isset($attributes['information'.$i]) && strip_tags($attributes['information'.$i])!=""): ?>
+          <?php if (Utils::richtext_content_exists($attributes, 'information'.$i)): ?>
           <p><?php echo urldecode($attributes['information'.$i]) ?: '' ?></p>
           <hr>
           <?php

--- a/frontend/lib/utils.php
+++ b/frontend/lib/utils.php
@@ -108,6 +108,17 @@ Class Utils
         return  sanitize_text_field((array_key_exists($name, $attributes))? $attributes[$name]: $default);
     }
 
+
+    /**
+     * Tells if an attribute associated with a Richtext field contains somethings.
+     * We use "strip_tags" function because if a value has been set and remove by user, Gutenberg let 
+     * an empty paragraph (<p></p>) 
+     */
+    public static function richtext_content_exists($attributes, $name)
+    {
+        return array_key_exists($name, $attributes) && strip_tags($attributes[$name]) != "";
+    }
+
 }
 
 ?>

--- a/frontend/lib/utils.php
+++ b/frontend/lib/utils.php
@@ -116,7 +116,7 @@ Class Utils
      */
     public static function richtext_content_exists($attributes, $name)
     {
-        return array_key_exists($name, $attributes) && strip_tags($attributes[$name]) != "";
+        return isset($attributes[$name]) && strip_tags($attributes[$name]) != "";
     }
 
 }

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.1.2
+ * Version: 1.1.3
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.1.1
+ * Version: 1.1.2
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/src/epfl-contact/index.js
+++ b/src/epfl-contact/index.js
@@ -23,7 +23,7 @@ const { Fragment } = wp.element;
 
 registerBlockType( 'epfl/contact', {
     title: __( 'EPFL Contact', 'wp-gutenberg-epfl'),
-    description: 'v1.0.3',
+    description: 'v1.0.4',
     icon: contactIcon,
     category: 'common',
     attributes: {


### PR DESCRIPTION
En lien avec INC0313677 (visible ici: https://www.epfl.ch/schools/sti/ateliers/afa/)
Lors du rendu, seul un check de la présence d'une information était fait avant de l'afficher. On ne regardait pas s'il y avait effectivement un contenu. Et même si c'est visuellement vide, Gutenberg ajoute quand même un `<p></p>` dans le contenu... donc, utilisation de la fonction `strip_tags()` pour supprimer les tags HTML et s'il ne reste plus qu'une chaîne vide après ça, on admet qu'il n'y a pas de contenu et on n'affiche rien.