### PR TITLE
Fix infoscience un-namespaced call

### DIFF
--- a/frontend/epfl-infoscience-search/renderers/publications.php
+++ b/frontend/epfl-infoscience-search/renderers/publications.php
@@ -29,21 +29,20 @@ function get_render_class_for_publication_2018($publication, $format) {
         $record_renderer_class_base = 'ShortInfosciencePublication2018Render';
     }
 
+    $full_record_renderer_class = __NAMESPACE__ . "\\" . $record_renderer_class_base;
+
     if (InfoscienceField2018Render::field_exists($publication['doctype'])) {
         # doctype determine the render, find it in the map
         $doctype_to_find = strtoupper($publication['doctype'][0]);
 
         if (array_key_exists($doctype_to_find, DOCTYPE_TO_CLASS_NAME_MAPPING)) {
-
-            $record_renderer_class = __NAMESPACE__ . "\\" .DOCTYPE_TO_CLASS_NAME_MAPPING[$doctype_to_find] . $record_renderer_class_base;
-
-            if (class_exists($record_renderer_class)) {
-                return $record_renderer_class;
-            }
+            return __NAMESPACE__ . "\\" . DOCTYPE_TO_CLASS_NAME_MAPPING[$doctype_to_find] . $record_renderer_class_base;
+        }  else {
+            return $full_record_renderer_class;
         }
+    } else {
+        return $full_record_renderer_class;
     }
-
-    return $record_renderer_class_base;
 }
 
 /*

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.1.1
+ * Version: 1.1.2
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/src/epfl-infoscience-search/index.js
+++ b/src/epfl-infoscience-search/index.js
@@ -12,7 +12,7 @@ const { Fragment } = wp.element;
 
 registerBlockType( 'epfl/infoscience-search', {
 	title: __( 'EPFL Infoscience', 'wp-gutenberg-epfl'),
-	description: 'v1.0.1',
+	description: 'v1.0.2',
 	icon: infoscienceIcon,
 	category: 'common',
 	attributes: {


### PR DESCRIPTION
Si un type de publications n'a pas de classe de rendu, la classe par défaut est utilisée. Le problème est que cette classe est défini sans le namespace.