### PR TITLE
Google Forms 1.0.6 - Fix horizontal align

### DIFF
--- a/frontend/epfl-google-forms/controller.php
+++ b/frontend/epfl-google-forms/controller.php
@@ -34,17 +34,15 @@ function epfl_google_forms_block( $attributes ) {
 
     /* Extracting needed attributes */
     $src = epfl_google_forms_get_attribute('src', $data);
-    $width = epfl_google_forms_get_attribute('width', $data);
     $height = epfl_google_forms_get_attribute('height', $data);
 
     /*
     var_dump($src);
-    var_dump($width);
     var_dump($height);
     */
 
     /* Checking if all attributes are present */
-    if($src===null || $height===null || $width===null)
+    if($src===null || $height===null)
     {
         return Utils::render_user_msg(__("Error extracting parameters", "epfl"));
     }
@@ -62,6 +60,6 @@ function epfl_google_forms_block( $attributes ) {
         return Utils::render_user_msg(__("Incorrect dimensions found", "epfl"));
     }
 
-    $markup = epfl_google_forms_render($src, $width, $height);
+    $markup = epfl_google_forms_render($src, $height);
     return $markup;
 }

--- a/frontend/epfl-google-forms/view.php
+++ b/frontend/epfl-google-forms/view.php
@@ -1,10 +1,11 @@
 <?php
     namespace EPFL\Plugins\Gutenberg\GoogleForms;
 
-    function epfl_google_forms_render($src, $width, $height) {
+    function epfl_google_forms_render($src, $height) {
 
-        $markup = '<div class="container my-3">';
-        $markup .= '<iframe src="' . esc_url($src) .'" width="' . esc_attr($width) . '" height="' . esc_attr($height) . '" frameborder="0" marginheight="0" marginwidth="0">';
+        $markup = '<div class="container my-3 centered">';
+        // We use 100% of width instead of the one present in iframe HTML code because otherwise, form is not centered in parent div
+        $markup .= '<iframe src="' . esc_url($src) .'" width="100%" height="' . esc_attr($height) . '" frameborder="0" marginheight="0" marginwidth="0">';
         $markup .= __("Loading...", "epfl");
         $markup .= '</iframe>';
         $markup .= '</div>';

--- a/src/epfl-google-forms/index.js
+++ b/src/epfl-google-forms/index.js
@@ -20,7 +20,7 @@ const { Fragment } = wp.element;
 
 registerBlockType( 'epfl/google-forms', {
 	title: __( 'Google Forms', 'wp-gutenberg-epfl'),
-	description: 'v1.0.5',
+	description: 'v1.0.6',
 	icon: googleFormsIcon,
 	category: 'common',
 	attributes: {


### PR DESCRIPTION
On met l'iframe du Google Form dans un `<div class="container my-3">` mais celui-ci n'aligne pas au centre les `<iframe>`... donc pour contourner le problème, au lieu de reprendre la largeur de l'iframe telle que fournie dans le code d'inclusion donné par Google, on met simplement `width="100%"` et ça fait le job.
Du coup, suppression de `$width` là où on l'utilise... 
Lié à INC0316299