### PR TITLE
Add a parameter to get_items to ignore ssl

### DIFF
--- a/frontend/lib/utils.php
+++ b/frontend/lib/utils.php
@@ -44,7 +44,7 @@ Class Utils
      * @param cache_time_sec : Nb of sec during which we have to cache information in transient
      * @return decoded JSON data
      */
-    public static function get_items(string $url, $cache_time_sec=300, $timeout=5) {
+    public static function get_items(string $url, $cache_time_sec=300, $timeout=5, $sslverify=True) {
         /* Generating unique transient ID. We cannot directly use URL (and replace some characters) because we are
         limited to 172 characters for transient identifiers (https://codex.wordpress.org/Transients_API) */
         $transient_id = 'epfl_'.md5($url);
@@ -67,7 +67,7 @@ Class Utils
         }
 
         $start = microtime(true);
-        $response = wp_remote_get($url, array( 'timeout' => $timeout ));
+        $response = wp_remote_get($url, array( 'timeout' => $timeout, 'sslverify' => $sslverify ));
         $end = microtime(true);
 
         // Logging call


### PR DESCRIPTION
J'ajoute cette option car il est nécessaire de ne pas activer la vérification SSL lorsque l'on se connecte à nos machines de tests, tel les endpoints de wp-veritas ou polylex.