### PR TITLE
Lock card panel again

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.5.4
+ * Version: 1.5.5
  */
 
 namespace EPFL\Plugins\Gutenberg;
@@ -61,6 +61,8 @@ function allow_epfl_blocks( $allowed_block_types, $post ) {
 
     // Reset value
     $allowed_block_types = [];
+    // We explicitely deny usage of epfl/card-panel block so we can't add more than 3 blocks inside an epfl/card-deck
+    $explicitly_denied_blocks = ['epfl/card-panel'];
 
     // Retrieving currently registered blocks
     $registered = \WP_Block_Type_Registry::get_instance()->get_all_registered();
@@ -68,7 +70,7 @@ function allow_epfl_blocks( $allowed_block_types, $post ) {
     // Looping through registered blocks to find "epfl/" ones
     foreach(array_keys($registered) as $block_name)
     {
-        if(preg_match('/^epfl\//', $block_name)===1)
+        if(preg_match('/^epfl\//', $block_name)===1 && !in_array($block_name, $explicitly_denied_blocks))
         {
             $allowed_block_types[] = $block_name;
         }

--- a/src/epfl-card-deck/index.js
+++ b/src/epfl-card-deck/index.js
@@ -64,9 +64,10 @@ registerBlockType( 'epfl/card-deck', {
                         <h2>EPFL Card Deck</h2>
                         <InnerBlocks
                             template={ TEMPLATE }
-                            /* We could lock template to deny adding new blocks but even if we remove the locking inside epfl/card-panel, there's a bug and the system removes the block inside epfl/card-panl block.
-                             So, as workaround, we don't lock but limit new blocks to 'epfl/card-panel'. And because this block is not present in the white list in MU-Plugin EPFL_custom_editor_menu.php, we won't
-                             be able to add new blocks inside and epfl/card-deck block */
+                            /* We could lock template to deny adding new blocks but even if we remove the locking inside epfl/card-panel, there's a bug and the system removes the 
+                             block inside epfl/card-panl block.
+                             So, as workaround, we don't lock but limit new blocks to 'epfl/card-panel'. And because this block is not present in the white list in 
+                             this plugin (plugin.php), we won't be able to add new blocks inside and epfl/card-deck block */
                             allowedBlocks={['epfl/card-panel']}
                            />
                 </div>


### PR DESCRIPTION
Suite à #142 une petite porte a été ouverte... (et heureusement que ça avait été bien commenté sur la manière de fonctionner car ça a permis de facilement résoudre la chose). Bref, en faisant en sorte que #142 autorise automatiquement tous les blocs définis dans le plugin EPFL Gutenberg, on avait de ce fait à nouveau permis l'ajout de plus de `epfl/card-panel` au sein d'un `epfl/card-deck`... 🤦‍♂ #shitHappens #forrestWeLoveYou #keepRunning
Donc, modification de la fonction d'autorisation automatique de tous les blocks `epfl/*` pour y ajouter une BLACK list (#notVIPBlocks) et simplement y mettre `epfl/card-panel`. Du coup, problem solved #usingEnglishMakeMeSmart !