### PR TITLE
Fix people function with manual trim

### DIFF
--- a/frontend/epfl-people/controller.php
+++ b/frontend/epfl-people/controller.php
@@ -59,7 +59,8 @@ function epfl_people_block( $attributes ) {
     $doctoral_program = preg_replace('/\s+/','',$doctoral_program);
     $structure = preg_replace('/\s+/','',$structure);
 
-    // Delete whitespace before and after , only
+    // Delete whitespace before and after each comma
+    // function can contain a whitespace
     $functions = explode(",", $function);
     $functions = array_map('trim', $functions);
     $function = implode(",",$functions); 

--- a/frontend/epfl-people/controller.php
+++ b/frontend/epfl-people/controller.php
@@ -46,7 +46,7 @@ function epfl_people_block( $attributes ) {
     var_dump($groups);
     var_dump($scipers);
     var_dump($doctoral_program);
-    var_dump($fonction);
+    var_dump($function);
     var_dump($columns);
     var_dump($order);
     var_dump($structure);
@@ -55,10 +55,14 @@ function epfl_people_block( $attributes ) {
     // Delete all whitespace (including tabs and line ends)
     $units = preg_replace('/\s+/','',$units);
     $groups = preg_replace('/\s+/','',$groups);
-    $function = preg_replace('/\s+/','',$function);
     $scipers = preg_replace('/\s+/','',$scipers);
     $doctoral_program = preg_replace('/\s+/','',$doctoral_program);
     $structure = preg_replace('/\s+/','',$structure);
+
+    // Delete whitespace before and after , only
+    $functions = explode(",", $function);
+    $functions = array_map('trim', $functions);
+    $function = implode(",",$functions); 
 
     if ($columns !== 'list') {
         $columns = (is_numeric($columns) && intval($columns) <= 3 && intval($columns) >= 1) ? $columns : 3;

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.5.9
+ * Version: 1.5.10
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/src/epfl-people/index.js
+++ b/src/epfl-people/index.js
@@ -12,7 +12,7 @@ registerBlockType(
 	'epfl/people',
 	{
 		title: __( "EPFL People", 'epfl'),
-		description: 'v1.1.7',
+		description: 'v1.1.8',
 		icon: newsIcon,
 		category: 'common',
 		keywords: [


### PR DESCRIPTION
Le paramètre fonction a pour but de filtrer les personnes par leur fonction. 
L'utilisateur peut saisir une liste de fonction en français séparé par des virgules.
On doit supprimer tous les espaces autour des fonctions, avant et après la virgule mais pas dans le libellé de la fonction.