### PR TITLE
Table filter v1.0.3 - Bugfix when exploding an empty string

### DIFF
--- a/frontend/epfl-table-filter/controller.php
+++ b/frontend/epfl-table-filter/controller.php
@@ -26,7 +26,8 @@ function epfl_table_filter_block($attributes, $inner_content)
   $header_options = Utils::get_sanitized_attribute( $attributes, 'tableHeaderOptions', '');
   
   // Filtering option
-  $filter_only_on_cols_array  = explode(",", Utils::get_sanitized_attribute( $attributes, 'filterOnlyOnCols', ''));
+  $filter_only_on_cols  = Utils::get_sanitized_attribute( $attributes, 'filterOnlyOnCols', '');
+  $filter_only_on_cols_array  = (trim($filter_only_on_cols)!='')? explode(",", $filter_only_on_cols) : array();
   // Some sanitize work
   $filter_only_on_cols_array = array_map("trim", $filter_only_on_cols_array);
   $filter_only_on_cols_array = array_map("intval", $filter_only_on_cols_array);

--- a/frontend/epfl-table-filter/js/table-filter.js
+++ b/frontend/epfl-table-filter/js/table-filter.js
@@ -43,7 +43,8 @@ $(".epfl-table-filter").each(function(filter_div_index, filter_div) {
     });
     
     // Getting header configuration for current table
-    header_options = $(filter_div).find('input[name="header"]').attr('value').split(',');
+    header_options = $(filter_div).find('input[name="header"]').attr('value');
+    header_options = (header_options.trim() != '')? header_options.split(','): [];
     
     if(header_options.length > 0)
     {

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.5.13
+ * Version: 1.5.14
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/src/epfl-table-filter/index.js
+++ b/src/epfl-table-filter/index.js
@@ -54,7 +54,7 @@ let optionsHeader = [
 
 registerBlockType( 'epfl/table-filter', {
 	title: __( 'EPFL Table Filter', 'epfl'),
-	description: 'v1.0.2',
+	description: 'v1.0.3',
 	icon: tableFilterIcon,
 	category: 'common',
 	attributes: getAttributes(),


### PR DESCRIPTION
Petit truc subtil que je n'avais pas testé ... quand on fait un `explode` (PHP) ou `split` (JS) d'une chaîne de caractères vide, ça ne retourne pas un tableau vide... ça retourne un tableau avec un élément vide... Donc le filtre sur les colonnes était mal pris en compte.
De plus, par défaut on formattait la première ligne du tableau comme étant un header.