### PR TITLE
Block registers own tags

### DIFF
--- a/frontend/epfl-google-forms/controller.php
+++ b/frontend/epfl-google-forms/controller.php
@@ -63,3 +63,19 @@ function epfl_google_forms_block( $attributes ) {
     $markup = epfl_google_forms_render($src, $height);
     return $markup;
 }
+
+
+/*
+    Add tags needed by block when we copy/paste HTML content to add a Google Form.
+    If we don't add tags to allowed list, they will be cleaned with WP version >5.2.4
+*/
+function add_block_allowed_tags($tags)
+{
+    if(!array_key_exists('iframe', $tags)) $tags['iframe'] = [];
+    $tags['iframe']['src'] = true;
+    $tags['iframe']['width'] = true;
+    $tags['iframe']['height'] = true;
+
+    return $tags;
+}
+add_filter('wp_kses_allowed_html', __NAMESPACE__.'\add_block_allowed_tags');

--- a/frontend/epfl-tableau/controller.php
+++ b/frontend/epfl-tableau/controller.php
@@ -62,3 +62,24 @@ function epfl_tableau_block( $attributes ) {
     $markup = epfl_tableau_render($tableau_name, $width, $height);
     return $markup;
 }
+
+
+
+/*
+    Add tags needed by block when we copy/paste HTML content to add a Tableau.
+    If we don't add tags to allowed list, they will be cleaned with WP version >5.2.4
+*/
+function add_block_allowed_tags($tags)
+{
+
+    if(!array_key_exists('object', $tags)) $tags['object'] = [];
+    $tags['object']['width'] = true;
+    $tags['object']['height'] = true;
+    
+    if(!array_key_exists('param', $tags)) $tags['param'] = [];
+    $tags['param']['name'] = true;
+    $tags['param']['value'] = true;
+
+    return $tags;
+}
+add_filter('wp_kses_allowed_html', __NAMESPACE__.'\add_block_allowed_tags');

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.6.0
+ * Version: 1.6.1
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/src/epfl-google-forms/index.js
+++ b/src/epfl-google-forms/index.js
@@ -19,7 +19,7 @@ const { Fragment } = wp.element;
 
 registerBlockType( 'epfl/google-forms', {
 	title: __( 'Google Forms', 'epfl'),
-	description: 'v1.0.7',
+	description: 'v1.0.8',
 	icon: googleFormsIcon,
 	category: 'common',
 	attributes: {

--- a/src/epfl-tableau/index.js
+++ b/src/epfl-tableau/index.js
@@ -21,7 +21,7 @@ const { Fragment } = wp.element;
 
 registerBlockType( 'epfl/tableau', {
 	title: __( 'EPFL Tableau', 'epfl'),
-	description: 'v1.0.6',
+	description: 'v1.0.7',
 	icon: tableauIcon,
 	category: 'common',
 	attributes: {


### PR DESCRIPTION
Depuis le passage à la version de WordPress 5.2.5 (le 12.12.2019), une fonction a été ajoutée dans le code qui effectue aussi un "clean" des tags HTML non autorisés au sein du contenu des blocs (et de leurs attributs!). Donc, pour les blocs comme `epfl/tableau` et `epfl/google-forms`, un nettoyage était effectué dès la sauvegarde de la page et plus rien ne fonctionnait... 

Actuellement, on a déjà un filtre dans le mu-plugin `epfl-functions.php` qui s'occupe d'ajouter des tags à la white-list (pour le bon fonctionnement du thème). 
Il a cependant été décidé de ne pas compléter ce filtre car si le mu-plugin n'est pas présent en même temps que le plugin `wp-gutenberg-epfl`, les 2 blocs susmentionnés ne fonctionneront pas... Du coup, il a été choisi d'ajouter le code nécessaire au sein de chacun des blocs, afin qu'ils ajoutent eux-mêmes les tags (et leurs attributs) dont ils ont besoin pour bien fonctionner.
Cela signifie qu'une partie du contenu copié-collé sera supprimé au moment de la sauvegarde de la page mais comme c'est du contenu inutile, ça ne posera pas de problème.

D'ailleurs, il serait bon de se poser la question si l'ajout des tags pour le thème ne devrait pas se faire au sein du thème. Mais reste à voir quelles seraient les conséquences pour les sites n'utilisant pas le thème EPFL (unmanaged?... mais s'ils n'ont pas le mu-plugin, aucun problème à priori... mais à réflexionner).