### PR TITLE
Video vimeo

### DIFF
--- a/frontend/epfl-news/controller.php
+++ b/frontend/epfl-news/controller.php
@@ -9,8 +9,15 @@
 namespace EPFL\Plugins\Gutenberg\News;
 use \EPFL\Plugins\Gutenberg\Lib\Utils;
 
-define(__NAMESPACE__ . "\NEWS_API_URL", "https://staging-actu.epfl.ch/api/v1/channels/");
-define(__NAMESPACE__ . "\"NEWS_API_URL_IFRAME", "https://staging-actu.epfl.ch/webservice_iframe/");
+define(__NAMESPACE__ . "\NEWS_PROD", true);
+if (NEWS_PROD) {
+  define(__NAMESPACE__ . "\BASE_NEWS_URL", "https://actu.epfl.ch");
+} else {
+  define(__NAMESPACE__ . "\BASE_NEWS_URL", "https://staging-actu.epfl.ch");
+}
+define(__NAMESPACE__ . "\NEWS_API_URL", BASE_NEWS_URL . "/api/v1/channels/");
+define(__NAMESPACE__ . "\"NEWS_API_URL_IFRAME", BASE_NEWS_URL . "/webservice_iframe/");
+
 require_once(dirname(__FILE__).'/../lib/utils.php');
 require_once(dirname(__FILE__).'/view.php');
 

--- a/frontend/epfl-news/controller.php
+++ b/frontend/epfl-news/controller.php
@@ -9,8 +9,8 @@
 namespace EPFL\Plugins\Gutenberg\News;
 use \EPFL\Plugins\Gutenberg\Lib\Utils;
 
-define(__NAMESPACE__ . "\NEWS_API_URL", "https://actu-test.epfl.ch/api/v1/channels/");
-define(__NAMESPACE__ . "\"NEWS_API_URL_IFRAME", "https://actu-test.epfl.ch/webservice_iframe/");
+define(__NAMESPACE__ . "\NEWS_API_URL", "https://staging-actu.epfl.ch/api/v1/channels/");
+define(__NAMESPACE__ . "\"NEWS_API_URL_IFRAME", "https://staging-actu.epfl.ch/webservice_iframe/");
 require_once(dirname(__FILE__).'/../lib/utils.php');
 require_once(dirname(__FILE__).'/view.php');
 

--- a/frontend/epfl-news/controller.php
+++ b/frontend/epfl-news/controller.php
@@ -9,9 +9,8 @@
 namespace EPFL\Plugins\Gutenberg\News;
 use \EPFL\Plugins\Gutenberg\Lib\Utils;
 
-define(__NAMESPACE__ . "\NEWS_URL", "https://actu.epfl.ch/");
-define(__NAMESPACE__ . "\NEWS_API_URL", "https://actu.epfl.ch/api/v1/channels/");
-define(__NAMESPACE__ . "\"NEWS_API_URL_IFRAME", "https://actu.epfl.ch/webservice_iframe/");
+define(__NAMESPACE__ . "\NEWS_API_URL", "https://actu-test.epfl.ch/api/v1/channels/");
+define(__NAMESPACE__ . "\"NEWS_API_URL_IFRAME", "https://actu-test.epfl.ch/webservice_iframe/");
 require_once(dirname(__FILE__).'/../lib/utils.php');
 require_once(dirname(__FILE__).'/view.php');
 

--- a/frontend/epfl-news/controller.php
+++ b/frontend/epfl-news/controller.php
@@ -9,6 +9,7 @@
 namespace EPFL\Plugins\Gutenberg\News;
 use \EPFL\Plugins\Gutenberg\Lib\Utils;
 
+define(__NAMESPACE__ . "\NEWS_URL", "https://actu.epfl.ch/");
 define(__NAMESPACE__ . "\NEWS_API_URL", "https://actu.epfl.ch/api/v1/channels/");
 define(__NAMESPACE__ . "\"NEWS_API_URL_IFRAME", "https://actu.epfl.ch/webservice_iframe/");
 require_once(dirname(__FILE__).'/../lib/utils.php');

--- a/frontend/epfl-news/templates/card_with_1_news.php
+++ b/frontend/epfl-news/templates/card_with_1_news.php
@@ -14,15 +14,17 @@
 
         foreach($results as $news) {
 
-            $is_first_event    = ($count==1);
-            $image_description = epfl_news_get_image_description($news);
-            $category          = epfl_news_get_label_category($news);
-            $publish_date      = epfl_news_get_publish_date($news);
-            $subtitle          = epfl_news_get_subtitle($news);
-            $visual_url        = epfl_news_get_visual_url($news);
-            $video_name        = "teaser_" . str_replace("https://actu.epfl.ch/news/", "", $news->news_url);
-            $media_url         = get_attachment_url_by_slug($video_name);
-
+            $is_first_event       = ($count==1);
+            $image_description    = epfl_news_get_image_description($news);
+            $category             = epfl_news_get_label_category($news);
+            $publish_date         = epfl_news_get_publish_date($news);
+            $subtitle             = epfl_news_get_subtitle($news);
+            $visual_url           = epfl_news_get_visual_url($news);
+            $short_vimeo_video_id = $news->short_vimeo_video_id;
+            
+            if ( !empty($short_vimeo_video_id) ) {	
+                $media_url = "https://player.vimeo.com/video/" . $short_vimeo_video_id . "?autoplay=1&loop=1&muted=1&background=1&quality=720";
+            }
             if ($is_first_event) {
                 $markup .= '<h2 class="mt-5 mb-4">';
                 $markup .= __('The latest news', 'epfl');

--- a/frontend/epfl-news/templates/card_with_1_news.php
+++ b/frontend/epfl-news/templates/card_with_1_news.php
@@ -20,11 +20,7 @@
             $publish_date         = epfl_news_get_publish_date($news);
             $subtitle             = epfl_news_get_subtitle($news);
             $visual_url           = epfl_news_get_visual_url($news);
-            $short_vimeo_video_id = $news->short_vimeo_video_id;
             
-            if ( !empty($short_vimeo_video_id) ) {	
-                $media_url = "https://player.vimeo.com/video/" . $short_vimeo_video_id . "?autoplay=1&loop=1&muted=1&background=1&quality=720";
-            }
             if ($is_first_event) {
                 $markup .= '<h2 class="mt-5 mb-4">';
                 $markup .= __('The latest news', 'epfl');

--- a/frontend/epfl-news/templates/card_with_2_news.php
+++ b/frontend/epfl-news/templates/card_with_2_news.php
@@ -13,14 +13,17 @@
 
         foreach($results as $news) {
 
-            $is_first_event    = ($count==1);
-            $image_description = epfl_news_get_image_description($news);
-            $category          = epfl_news_get_label_category($news);
-            $publish_date      = epfl_news_get_publish_date($news);
-            $subtitle          = epfl_news_get_subtitle($news);
-            $visual_url        = epfl_news_get_visual_url($news);
-            $video_name        = "teaser_" . str_replace("https://actu.epfl.ch/news/", "", $news->news_url);
-            $media_url         = get_attachment_url_by_slug($video_name);
+            $is_first_event       = ($count==1);
+            $image_description    = epfl_news_get_image_description($news);
+            $category             = epfl_news_get_label_category($news);
+            $publish_date         = epfl_news_get_publish_date($news);
+            $subtitle             = epfl_news_get_subtitle($news);
+            $visual_url           = epfl_news_get_visual_url($news);
+            $short_vimeo_video_id = $news->short_vimeo_video_id;
+
+            if ( !empty($short_vimeo_video_id) ) {	
+                $media_url = "https://player.vimeo.com/video/" . $short_vimeo_video_id . "?autoplay=1&loop=1&muted=1&background=1&quality=720";
+            }
 
             if ($is_first_event) {
                 $markup .= '<h2 class="mt-5 mb-4">';

--- a/frontend/epfl-news/templates/card_with_2_news.php
+++ b/frontend/epfl-news/templates/card_with_2_news.php
@@ -19,12 +19,7 @@
             $publish_date         = epfl_news_get_publish_date($news);
             $subtitle             = epfl_news_get_subtitle($news);
             $visual_url           = epfl_news_get_visual_url($news);
-            $short_vimeo_video_id = $news->short_vimeo_video_id;
-
-            if ( !empty($short_vimeo_video_id) ) {	
-                $media_url = "https://player.vimeo.com/video/" . $short_vimeo_video_id . "?autoplay=1&loop=1&muted=1&background=1&quality=720";
-            }
-
+            
             if ($is_first_event) {
                 $markup .= '<h2 class="mt-5 mb-4">';
                 $markup .= __('The latest news', 'epfl');

--- a/frontend/epfl-news/templates/card_with_3_news.php
+++ b/frontend/epfl-news/templates/card_with_3_news.php
@@ -20,11 +20,6 @@
             $publish_date      = epfl_news_get_publish_date($news);
             $subtitle          = epfl_news_get_subtitle($news);
             $visual_url        = epfl_news_get_visual_url($news);
-            $short_vimeo_video_id = $news->short_vimeo_video_id;
-
-            if ( !empty($short_vimeo_video_id) ) {	
-                $media_url = "https://player.vimeo.com/video/" . $short_vimeo_video_id . "?autoplay=1&loop=1&muted=1&background=1&quality=720";
-            }
 
             if ($is_first_event) {
                 $markup .= '<h2 class="mt-5 mb-4">';

--- a/frontend/epfl-news/templates/card_with_3_news.php
+++ b/frontend/epfl-news/templates/card_with_3_news.php
@@ -20,8 +20,11 @@
             $publish_date      = epfl_news_get_publish_date($news);
             $subtitle          = epfl_news_get_subtitle($news);
             $visual_url        = epfl_news_get_visual_url($news);
-            $video_name        = "teaser_" . str_replace("https://actu.epfl.ch/news/", "", $news->news_url);
-            $media_url         = get_attachment_url_by_slug($video_name);
+            $short_vimeo_video_id = $news->short_vimeo_video_id;
+
+            if ( !empty($short_vimeo_video_id) ) {	
+                $media_url = "https://player.vimeo.com/video/" . $short_vimeo_video_id . "?autoplay=1&loop=1&muted=1&background=1&quality=720";
+            }
 
             if ($is_first_event) {
                 $markup .= '<h2 class="mt-5 mb-4">';

--- a/frontend/epfl-news/templates/highlighted_with_1_news.php
+++ b/frontend/epfl-news/templates/highlighted_with_1_news.php
@@ -14,15 +14,17 @@
 
         foreach($results as $news) {
 
-            $is_first_event    = ($count==1);
-            $image_description = epfl_news_get_image_description($news);
-            $category          = epfl_news_get_label_category($news);
-            $publish_date      = epfl_news_get_publish_date($news);
-            $subtitle          = epfl_news_get_subtitle($news);
-            $visual_url        = epfl_news_get_visual_url($news);
-            $video_name        = "teaser_" . str_replace("https://actu.epfl.ch/news/", "", $news->news_url);
-            $media_url         = get_attachment_url_by_slug($video_name);
+            $is_first_event       = ($count==1);
+            $image_description    = epfl_news_get_image_description($news);
+            $category             = epfl_news_get_label_category($news);
+            $publish_date         = epfl_news_get_publish_date($news);
+            $subtitle             = epfl_news_get_subtitle($news);
+            $visual_url           = epfl_news_get_visual_url($news);
+            $short_vimeo_video_id = $news->short_vimeo_video_id;
 
+            if ( !empty($short_vimeo_video_id) ) {	
+                $media_url = "https://player.vimeo.com/video/" . $short_vimeo_video_id . "?autoplay=1&loop=1&muted=1&background=1&quality=720";
+            }
             $markup .= '<div class="fullwidth-teaser fullwidth-teaser-horizontal">';
             if ($media_url) {
                 $markup .= '<div class="embed-responsive embed-responsive-16by9">';

--- a/frontend/epfl-news/templates/highlighted_with_1_news.php
+++ b/frontend/epfl-news/templates/highlighted_with_1_news.php
@@ -25,13 +25,11 @@
             if ( !empty($short_vimeo_video_id) ) {	
                 $media_url = "https://player.vimeo.com/video/" . $short_vimeo_video_id . "?autoplay=1&loop=1&muted=1&background=1&quality=720";
             }
+    
             $markup .= '<div class="fullwidth-teaser fullwidth-teaser-horizontal">';
             if ($media_url) {
                 $markup .= '<div class="embed-responsive embed-responsive-16by9">';
-                $markup .= '<video autoplay muted loop>';
-                $markup .= '<source class="embed-responsive-item" src="' . $media_url; '" type="video/mp4">';
-                $markup .= 'Your browser does not support HTML5 video.';
-                $markup .= '</video>';
+                $markup .= '<iframe src="' . $media_url . '" frameborder="1"></iframe>';
                 $markup .= '</div>';
             } else {
                 $markup .= '<picture>';

--- a/frontend/epfl-news/templates/highlighted_with_3_news.php
+++ b/frontend/epfl-news/templates/highlighted_with_3_news.php
@@ -40,10 +40,7 @@
                 $markup .= '<div class="fullwidth-teaser fullwidth-teaser-horizontal">';
                 if ($media_url) {
                     $markup .= '<div class="embed-responsive embed-responsive-16by9">';
-                    $markup .= '<video autoplay muted loop>';
-                    $markup .= '<source class="embed-responsive-item" src="' . $media_url . '" type="video/mp4">';
-                    $markup .= 'Your browser does not support HTML5 video.';
-                    $markup .= '</video>';
+                    $markup .= '<iframe src="' . $media_url . '" frameborder="1"></iframe>';
                     $markup .= '</div>';
                 } else {
                     $markup .= '<picture>';

--- a/frontend/epfl-news/templates/highlighted_with_3_news.php
+++ b/frontend/epfl-news/templates/highlighted_with_3_news.php
@@ -16,14 +16,17 @@
 
         foreach($results as $news) {
 
-            $is_first_event    = ($count==1);
-            $image_description = epfl_news_get_image_description($news);
-            $category          = epfl_news_get_label_category($news);
-            $publish_date      = epfl_news_get_publish_date($news);
-            $subtitle          = epfl_news_get_subtitle($news);
-            $visual_url        = epfl_news_get_visual_url($news);
-            $video_name        = "teaser_" . str_replace("https://actu.epfl.ch/news/", "", $news->news_url);
-            $media_url         = get_attachment_url_by_slug($video_name);
+            $is_first_event       = ($count==1);
+            $image_description    = epfl_news_get_image_description($news);
+            $category             = epfl_news_get_label_category($news);
+            $publish_date         = epfl_news_get_publish_date($news);
+            $subtitle             = epfl_news_get_subtitle($news);
+            $visual_url           = epfl_news_get_visual_url($news);
+            $short_vimeo_video_id = $news->short_vimeo_video_id;
+
+            if ( !empty($short_vimeo_video_id) ) {	
+              $media_url = "https://player.vimeo.com/video/" . $short_vimeo_video_id . "?autoplay=1&loop=1&muted=1&background=1&quality=720";
+            }
 
             if (1 != $count and false == $header) {
                 $header = true;

--- a/frontend/epfl-news/templates/listing.php
+++ b/frontend/epfl-news/templates/listing.php
@@ -13,15 +13,13 @@
 
         foreach($results as $news) {
 
-            $is_first_event    = ($count==1);
-            $image_description = epfl_news_get_image_description($news);
-            $category          = epfl_news_get_label_category($news);
-            $publish_date      = epfl_news_get_publish_date($news);
-            $subtitle          = epfl_news_get_subtitle($news);
-            $visual_url        = epfl_news_get_visual_url($news);
-            $video_name        = "teaser_" . str_replace("https://actu.epfl.ch/news/", "", $news->news_url);
-            $media_url         = get_attachment_url_by_slug($video_name);
-
+            $is_first_event       = ($count==1);
+            $image_description    = epfl_news_get_image_description($news);
+            $category             = epfl_news_get_label_category($news);
+            $publish_date         = epfl_news_get_publish_date($news);
+            $subtitle             = epfl_news_get_subtitle($news);
+            $visual_url           = epfl_news_get_visual_url($news);
+            
             $markup .= '<a href="' . esc_url($news->news_url) . '" class="list-group-item list-group-teaser link-trapeze-vertical">';
             $markup .= '<div class="list-group-teaser-container">';
             $markup .= '<div class="list-group-teaser-thumbnail">';

--- a/frontend/epfl-news/utils.php
+++ b/frontend/epfl-news/utils.php
@@ -9,7 +9,7 @@ namespace EPFL\Plugins\Gutenberg\News;
 function epfl_news_get_url_channel($data) {
     $url_channel = "";
     if (count($data) > 0) {
-        $url_channel .= "https://actu-test.epfl.ch/search/";
+        $url_channel .= "https://staging-actu.epfl.ch/search/";
         if (get_locale() == 'fr_FR') {
             $url_channel .= "fr/";
         } else {

--- a/frontend/epfl-news/utils.php
+++ b/frontend/epfl-news/utils.php
@@ -9,7 +9,7 @@ namespace EPFL\Plugins\Gutenberg\News;
 function epfl_news_get_url_channel($data) {
     $url_channel = "";
     if (count($data) > 0) {
-        $url_channel .= "https://staging-actu.epfl.ch/search/";
+        $url_channel .= BASE_NEWS_URL . "/search/";
         if (get_locale() == 'fr_FR') {
             $url_channel .= "fr/";
         } else {

--- a/frontend/epfl-news/utils.php
+++ b/frontend/epfl-news/utils.php
@@ -9,7 +9,7 @@ namespace EPFL\Plugins\Gutenberg\News;
 function epfl_news_get_url_channel($data) {
     $url_channel = "";
     if (count($data) > 0) {
-        $url_channel .= "https://actu.epfl.ch/search/";
+        $url_channel .= "https://actu-test.epfl.ch/search/";
         if (get_locale() == 'fr_FR') {
             $url_channel .= "fr/";
         } else {

--- a/plugin.php
+++ b/plugin.php
@@ -23,7 +23,7 @@ function epfl_gutenberg_load_textdomain() {
 	load_plugin_textdomain( 'epfl', FALSE, basename( dirname( __FILE__ ) ) . '/languages/' );
 }
 add_action( 'plugins_loaded',  __NAMESPACE__ . '\epfl_gutenberg_load_textdomain' );
-/*
+
 # allow to fetch rest api with the lang parameter
 function polylang_json_api_init() {
     global $polylang;
@@ -47,7 +47,7 @@ function polylang_json_api_languages() {
 
 // fix polylang language segmentation
 add_action( 'rest_api_init' , __NAMESPACE__ . '\polylang_json_api_init' );
-*/
+
 /**
  * Only allow blocks starting with "epfl/" in editor. If others blocks have to be allowed too, comoing from WordPress
  * or others plugins, you'll have to add another filter to add them, for example in a MU-Plugin. But be careful to

--- a/plugin.php
+++ b/plugin.php
@@ -23,7 +23,7 @@ function epfl_gutenberg_load_textdomain() {
 	load_plugin_textdomain( 'epfl', FALSE, basename( dirname( __FILE__ ) ) . '/languages/' );
 }
 add_action( 'plugins_loaded',  __NAMESPACE__ . '\epfl_gutenberg_load_textdomain' );
-
+/*
 # allow to fetch rest api with the lang parameter
 function polylang_json_api_init() {
     global $polylang;
@@ -47,7 +47,7 @@ function polylang_json_api_languages() {
 
 // fix polylang language segmentation
 add_action( 'rest_api_init' , __NAMESPACE__ . '\polylang_json_api_init' );
-
+*/
 /**
  * Only allow blocks starting with "epfl/" in editor. If others blocks have to be allowed too, comoing from WordPress
  * or others plugins, you'll have to add another filter to add them, for example in a MU-Plugin. But be careful to

--- a/src/epfl-news/index.js
+++ b/src/epfl-news/index.js
@@ -3,6 +3,7 @@ import './editor.scss'
 import newsIcon from './news-icon'
 import PreviewNews from './preview'
 import InspectorControlsNews from './inspector'
+import './utils.js';
 
 const { __ } = wp.i18n
 const { registerBlockType } = wp.blocks

--- a/src/epfl-news/inspector.js
+++ b/src/epfl-news/inspector.js
@@ -33,7 +33,7 @@ export default class InspectorControlsNews extends Component {
 
     componentDidMount() {
 
-        let apiRestUrl = BASE_API_REST_URL;
+        let apiRestUrl = BASE_NEWS_API_REST_URL;
 
         let entryPointChannels = `${apiRestUrl}channels/?format=json&limit=800`;
 		    axios.get(entryPointChannels)
@@ -72,7 +72,7 @@ export default class InspectorControlsNews extends Component {
             this.props.attributes.sections = null;
 
             this.setState({ selectedChannelId: this.props.attributes.channel });
-            let entryPointsSections = `${BASE_API_REST_URL}channels/${this.props.attributes.channel}/projects/?format=json&limit=10`;
+            let entryPointsSections = `${BASE_NEWS_API_REST_URL}channels/${this.props.attributes.channel}/projects/?format=json&limit=10`;
             
             axios.get(entryPointsSections)
                 .then( response => response.data )

--- a/src/epfl-news/inspector.js
+++ b/src/epfl-news/inspector.js
@@ -33,7 +33,7 @@ export default class InspectorControlsNews extends Component {
 
     componentDidMount() {
 
-        let apiRestUrl = "https://actu.epfl.ch/api/v1/";
+        let apiRestUrl = BASE_API_REST_URL;
 
         let entryPointChannels = `${apiRestUrl}channels/?format=json&limit=800`;
 		    axios.get(entryPointChannels)
@@ -72,7 +72,7 @@ export default class InspectorControlsNews extends Component {
             this.props.attributes.sections = null;
 
             this.setState({ selectedChannelId: this.props.attributes.channel });
-            let entryPointsSections = `https://actu.epfl.ch/api/v1/channels/${this.props.attributes.channel}/projects/?format=json&limit=10`;
+            let entryPointsSections = `${BASE_API_REST_URL}channels/${this.props.attributes.channel}/projects/?format=json&limit=10`;
             
             axios.get(entryPointsSections)
                 .then( response => response.data )

--- a/src/epfl-news/preview.js
+++ b/src/epfl-news/preview.js
@@ -17,7 +17,7 @@ export default class PreviewNews extends Component {
 	getURL() {
 		const { attributes } = this.props;
 
-    let newsUrl = `${BASE_API_REST_URL}channels/${attributes.channel}/news/`;
+    let newsUrl = `${BASE_NEWS_API_REST_URL}channels/${attributes.channel}/news/`;
     newsUrl += `?format=json&lang=${attributes.lang}&limit=${attributes.nbNews}`;
 
 		if (attributes.category !== 0) {

--- a/src/epfl-news/preview.js
+++ b/src/epfl-news/preview.js
@@ -17,7 +17,7 @@ export default class PreviewNews extends Component {
 	getURL() {
 		const { attributes } = this.props;
 
-    let newsUrl = `https://actu.epfl.ch/api/v1/channels/${attributes.channel}/news/`;
+    let newsUrl = `${BASE_API_REST_URL}channels/${attributes.channel}/news/`;
     newsUrl += `?format=json&lang=${attributes.lang}&limit=${attributes.nbNews}`;
 
 		if (attributes.category !== 0) {

--- a/src/epfl-news/utils.js
+++ b/src/epfl-news/utils.js
@@ -1,0 +1,1 @@
+global.BASE_API_REST_URL = "https://actu-test.epfl.ch/api/v1/";

--- a/src/epfl-news/utils.js
+++ b/src/epfl-news/utils.js
@@ -1,1 +1,6 @@
-global.BASE_API_REST_URL = "https://staging-actu.epfl.ch/api/v1/";
+const prod = true;
+if (prod) {
+  global.BASE_NEWS_API_REST_URL = "https://actu.epfl.ch/api/v1/";
+} else {
+  global.BASE_NEWS_API_REST_URL = "https://staging-actu.epfl.ch/api/v1/";
+}

--- a/src/epfl-news/utils.js
+++ b/src/epfl-news/utils.js
@@ -1,1 +1,1 @@
-global.BASE_API_REST_URL = "https://actu-test.epfl.ch/api/v1/";
+global.BASE_API_REST_URL = "https://staging-actu.epfl.ch/api/v1/";


### PR DESCRIPTION
Lors du passage à Gutenberg, on a perdu le code qui permettait de gérer la video de vimeo d'une actu qui, si elle est présente, doit être affichée à la place du visuel.

Je profite de cette PR pour faciliter le test du bloc epfl-news en pouvant tester nos développements à partir de serveur de staging d'actu à savoir https://staging-actu.epfl.ch/

Petit nettoyage dans certains templates qui n'utilisent pas la video mais dont une trace de l'ancienne gestion de la vidéo était présente