### PR TITLE
Fix url encoding bug introduced in WP 5.2.5

### DIFF
--- a/frontend/epfl-infoscience-search/controller.php
+++ b/frontend/epfl-infoscience-search/controller.php
@@ -128,7 +128,7 @@ function epfl_infoscience_search_block( $provided_attributes ) {
     # 1. direct url -> $attributes['url']
     # 2. url attribute ->
     # 3. with all the attributes, we built a custom one
-    $url = $attributes['url'];
+    $url = htmlspecialchars_decode($attributes['url']);
 
     if ($url) {
         $url = trim($url);

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.7.0
+ * Version: 1.7.1
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/src/epfl-infoscience-search/index.js
+++ b/src/epfl-infoscience-search/index.js
@@ -12,7 +12,7 @@ const { Fragment } = wp.element;
 
 registerBlockType( 'epfl/infoscience-search', {
 	title: __( 'EPFL Infoscience', 'epfl'),
-	description: 'v1.1.0',
+	description: 'v1.1.1',
 	icon: infoscienceIcon,
 	category: 'common',
 	attributes: {


### PR DESCRIPTION
Avec le passage en WP 5.2.5, Gutenberg semble maintenant renvoyer les URL au format "encodé" (`&amp;` à la place de `&`, même si on a mis ce dernier quand on a entré l'URL) au code qui effectue le rendu des blocs (dans le paramètre `$attributes`). Et pour le bloc "infoscience search", on utilise la fonction `parse_url` pour récupérer les paramètre de "query". Et donc là, chaque paramètre se voyait préfixé par `amp;` (sans le `&` vu qu'il a été utilisé pour séparer les paramètres), ce qui donne par exemple: 
```
array (
  'ln' => 'fr',
  'amp;p' => 'unit%3Aupbarth',
  'amp;f' => '',
  'amp;rm' => '',
  'amp;ln' => 'fr',
  'amp;sf' => 'latest+first',
  'amp;so' => 'd',
  'amp;rg' => '10',
  'amp;c' => 'Infoscience',
  'amp;of' => 'hb',
)

```

Il faut donc utiliser la fonction `htmlspecialchars_decode()` pour retransformer l'URL dans un format exploitable par `parse_url()`. Après avoir fait ceci, les paramètres sont correctement récupérés:
```
array (
  'ln' => 
  array (
    0 => 'fr',
    1 => 'fr',
  ),
  'p' => 'unit%3Aupbarth',
  'f' => '',
  'rm' => '',
  'sf' => 'latest+first',
  'so' => 'd',
  'rg' => '10',
  'c' => 'Infoscience',
  'of' => 'hb',
)
```