### PR TITLE
EPFL Links group take only first link...

### DIFF
--- a/frontend/epfl-links-group/controller.php
+++ b/frontend/epfl-links-group/controller.php
@@ -16,9 +16,12 @@ function epfl_links_group_block( $attributes ) {
 
   $links = [];
 
-  for($i=1; $i<=1; $i++)
+  for($i=1; $i<=10; $i++)
   {
-    $links[] = array('label' => Utils::get_sanitized_attribute( $attributes, 'label'.$i ),
+    $link_label = Utils::get_sanitized_attribute( $attributes, 'label'.$i );
+    if(trim($link_label)=="") continue;
+    
+    $links[] = array('label' => $link_label,
                      'url'   => Utils::get_sanitized_attribute( $attributes, 'url'.$i ));
   }
 

--- a/frontend/epfl-links-group/controller.php
+++ b/frontend/epfl-links-group/controller.php
@@ -19,10 +19,12 @@ function epfl_links_group_block( $attributes ) {
   for($i=1; $i<=10; $i++)
   {
     $link_label = Utils::get_sanitized_attribute( $attributes, 'label'.$i );
-    if(trim($link_label)=="") continue;
-    
+    $link_url = Utils::get_sanitized_attribute( $attributes, 'url'.$i );
+    // we skip empty values
+    if($link_label=="" || $link_url == "") continue;
+
     $links[] = array('label' => $link_label,
-                     'url'   => Utils::get_sanitized_attribute( $attributes, 'url'.$i ));
+                     'url'   => $link_url);
   }
 
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.7.1
+ * Version: 1.7.2
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/src/epfl-links-group/index.js
+++ b/src/epfl-links-group/index.js
@@ -59,13 +59,11 @@ function LinkGroupPanel ( props ) {
                 label={ __('Label', 'epfl') }
                 value={ attributes['label' + index] || ''}
                 onChange={ value => setIndexedAttributes('label', value) }
-                help= { __('Link label', 'epfl') }
             />
             <TextControl
                 label={ __('URL', 'epfl') }
                 value={ attributes['url' + index]  || '' }
                 onChange={ value => setIndexedAttributes('url', value) }
-                help= { __('Link URL', 'epfl') }
             />
             <hr />
         </div>
@@ -74,7 +72,7 @@ function LinkGroupPanel ( props ) {
 
 registerBlockType( 'epfl/links-group', {
 	title: __( 'EPFL Links group', 'epfl'),
-	description: 'v1.1.4',
+	description: 'v1.1.5',
 	icon: 'editor-kitchensink',
 	category: 'common',
 	attributes: getAttributes(),


### PR DESCRIPTION
Correction de quelques éléments :
- A cause d'une mauvaise valeur de condition d'arrêt de boucle `for`, seul le premier lien de la liste était pris
- Ajout du "skip" des liens dont l'URL ou le label est vide afin qu'ils ne soient pas affichés.
- Suppression d'un "help" affiché sous les champs d'édition qui faisait un peu trop doublon avec l'intitulé du champ