### PR TITLE
Add mechamism to deny block in posts

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -64,15 +64,14 @@ function allow_epfl_blocks( $allowed_block_types, $post ) {
     // We explicitely deny usage of epfl/card-panel block so we can't add more than 3 blocks inside an epfl/card-deck
     $explicitly_denied_blocks = ['epfl/card-panel'];
 
-    // If we're on a post, we add denied blocks to list
-    if($post->post_type == 'post')
-    {
-        // Blocks that are explicitely denied on Posts elements
-        $explicitly_posts_denied_blocks = ['epfl/hero'];
-
-        $explicitly_denied_blocks = array_merge($explicitly_denied_blocks, $explicitly_posts_denied_blocks);
-    }
-
+    // Blocks allowed in Posts
+    $posts_blocks_white_list = ['epfl/button',
+                                'epfl/links-group',
+                                'epfl/map',
+                                'epfl/toggle',
+                                'epfl/quote',
+                                'epfl/video'];
+    
     // Retrieving currently registered blocks
     $registered = \WP_Block_Type_Registry::get_instance()->get_all_registered();
 
@@ -81,7 +80,19 @@ function allow_epfl_blocks( $allowed_block_types, $post ) {
     {
         if(preg_match('/^epfl\//', $block_name)===1 && !in_array($block_name, $explicitly_denied_blocks))
         {
-            $allowed_block_types[] = $block_name;
+            if($post->post_type == 'post')
+            {
+                $block_ok = in_array($block_name, $posts_blocks_white_list);
+            }
+            else
+            {
+                $block_ok = true;
+            }
+
+            if($block_ok)
+            {
+                $allowed_block_types[] = $block_name;
+            }
         }
     }
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: wp-gutenberg-epfl
  * Description: EPFL Gutenberg Blocks
  * Author: WordPress EPFL Team
- * Version: 1.7.6
+ * Version: 1.7.7
  */
 
 namespace EPFL\Plugins\Gutenberg;

--- a/plugin.php
+++ b/plugin.php
@@ -64,6 +64,15 @@ function allow_epfl_blocks( $allowed_block_types, $post ) {
     // We explicitely deny usage of epfl/card-panel block so we can't add more than 3 blocks inside an epfl/card-deck
     $explicitly_denied_blocks = ['epfl/card-panel'];
 
+    // If we're on a post, we add denied blocks to list
+    if($post->post_type == 'post')
+    {
+        // Blocks that are explicitely denied on Posts elements
+        $explicitly_posts_denied_blocks = ['epfl/hero'];
+
+        $explicitly_denied_blocks = array_merge($explicitly_denied_blocks, $explicitly_posts_denied_blocks);
+    }
+
     // Retrieving currently registered blocks
     $registered = \WP_Block_Type_Registry::get_instance()->get_all_registered();
 


### PR DESCRIPTION
Limite la liste des blocs "EPFL" autorisés dans les Posts. 

PR en lien avec https://github.com/epfl-idevelop/jahia2wp/pull/1143 qui se charge de limiter les blocs "non-EPFL"

https://epfl-webvolution.atlassian.net/browse/WWP-83